### PR TITLE
Reorder Setup Calls

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,8 +36,8 @@ def main():
     """Main training and prediction pipeline."""
     try:
         # Setup
-        setup_logging()
         setup_directories()
+        setup_logging()
         logging.info("Starting training pipeline")
         
         # Load and process data


### PR DESCRIPTION
**Issue**
- `setup_logging` was being called before `setup_directories`, which leads to an error if the /logs subdir does not exist yet.

**Changes Made:**
- Reordered the function calls so that `setup_directories` is executed before `setup_logging`.